### PR TITLE
Added public extension to XliffFileDumper

### DIFF
--- a/Translation/Dumper/XliffFileDumper.php
+++ b/Translation/Dumper/XliffFileDumper.php
@@ -126,4 +126,12 @@ class XliffFileDumper extends BaseXliffFileDumper
 
         return $context;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getExtension()
+    {
+        return 'xlf';
+    }
 }


### PR DESCRIPTION
This is required by PrestaShop in order to know which dumper execute.