### PR TITLE
Disabled twig extension by default

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -54,12 +54,5 @@ services:
         tags:
           - { name: prestashop.translation.extractor, format: smarty }
 
-    prestashop.twig.extension.app:
-        class: PrestaShop\TranslationToolsBundle\Twig\Extension\AppExtension
-        arguments:
-            - "@translator"
-        tags:
-          - { name: twig.extension }
-          
     prestashop.dumper.xliff:
         class: PrestaShop\TranslationToolsBundle\Translation\Dumper\XliffFileDumper


### PR DESCRIPTION
This extension alter the behavior of a lot of PrestaShop twig extension, we don't want to in PrestaShop project.

So the extension is disabled and you'll have to register it by yourself if required.