### PR TITLE
Introduced new Flattenizer

### DIFF
--- a/Tests/Translation/Extractor/Util/FlattenizerTest.php
+++ b/Tests/Translation/Extractor/Util/FlattenizerTest.php
@@ -2,18 +2,48 @@
 
 namespace PrestaShop\TranslationToolsBundle\Tests\Translation\Extractor;
 
+use PrestaShop\TranslationToolsBundle\Translation\Extractor\Util\Flattenizer;
+
+use Symfony\Component\Filesystem\Filesystem;
+
 class FlattenizerTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    private static $fixturesPath;
+    private static $fs;
+    private static $outputPath;
+
+    public static function setUpBeforeClass()
     {
+        self::$fixturesPath = self::path('flattenizer/en-US');
+        self::$fs = new Filesystem();
+        self::$outputPath = self::path('flattenized-translations');
     }
 
-    public function tearDown()
+    public static function tearDownAfterClass()
     {
+        self::$fs->remove(self::$outputPath);
     }
 
     public function testFlatten()
     {
-        $this->markTestSkipped('To be written soon :)')
+        $done = Flattenizer::flatten(
+            self::$fixturesPath,
+            self::$outputPath,'en-US'
+        );
+
+        $this->assertTrue($done);
+        $isFilesExists = self::$fs->exists(array(
+            self::$outputPath.'/ShopFooBar.en-US.xlf',
+            self::$outputPath.'/ShopThemeActions.en-US.xlf',
+            self::$outputPath.'/ShopThemeProduct.en-US.xlf',
+            self::$outputPath.'/ShopThemeCart.en-US.xlf',
+        ));
+
+        $this->assertTrue($isFilesExists);
+    }
+    
+    private static function path($resourceName)
+    {
+        return __DIR__.'/../../../resources/'.$resourceName;
     }
 }

--- a/Tests/Translation/Extractor/Util/FlattenizerTest.php
+++ b/Tests/Translation/Extractor/Util/FlattenizerTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace PrestaShop\TranslationToolsBundle\Tests\Translation\Extractor;
+
+class FlattenizerTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+    }
+
+    public function tearDown()
+    {
+    }
+
+    public function testFlatten()
+    {
+        $this->markTestSkipped('To be written soon :)')
+    }
+}

--- a/Tests/resources/flattenizer/en-US/Shop/Foo/Bar.xlf
+++ b/Tests/resources/flattenizer/en-US/Shop/Foo/Bar.xlf
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="home/ubuntu/workspace/PrestaShop/src/PrestaShopBundle/Tests/resources/themes/fake-theme/templates/checkout/cart.tpl" source-language="en_US_POSIX" target-language="en-US" datatype="plaintext">
+    <body>
+      <trans-unit id="d1a2ba84e96d5baba4aff54f471d44d4">
+        <source>Cancel cart</source>
+        <target>Cancel cart</target>
+        <note>Context:
+File: home/ubuntu/workspace/PrestaShop/src/PrestaShopBundle/Tests/resources/themes/fake-theme/templates/checkout/cart.tpl:2</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Tests/resources/flattenizer/en-US/Shop/Theme/Actions.xlf
+++ b/Tests/resources/flattenizer/en-US/Shop/Theme/Actions.xlf
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="home/ubuntu/workspace/PrestaShop/src/PrestaShopBundle/Tests/resources/themes/fake-theme/templates/page.tpl" source-language="en_US_POSIX" target-language="en-US" datatype="plaintext">
+    <body>
+      <trans-unit id="63a6a88c066880c5ac42394a22803ca6">
+        <source>Refresh</source>
+        <target>Refresh</target>
+        <note>Context:
+File: home/ubuntu/workspace/PrestaShop/src/PrestaShopBundle/Tests/resources/themes/fake-theme/templates/page.tpl:1</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Tests/resources/flattenizer/en-US/Shop/Theme/Cart.xlf
+++ b/Tests/resources/flattenizer/en-US/Shop/Theme/Cart.xlf
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="home/ubuntu/workspace/PrestaShop/src/PrestaShopBundle/Tests/resources/themes/fake-theme/templates/checkout/cart.tpl" source-language="en_US_POSIX" target-language="en-US" datatype="plaintext">
+    <body>
+      <trans-unit id="1f379957091c42f23ad4e3840f0b0a65">
+        <source>Apply cart</source>
+        <target>Apply cart</target>
+        <note>Context:
+File: home/ubuntu/workspace/PrestaShop/src/PrestaShopBundle/Tests/resources/themes/fake-theme/templates/checkout/cart.tpl:1</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Tests/resources/flattenizer/en-US/Shop/Theme/Product.xlf
+++ b/Tests/resources/flattenizer/en-US/Shop/Theme/Product.xlf
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="home/ubuntu/workspace/PrestaShop/src/PrestaShopBundle/Tests/resources/themes/fake-theme/templates/catalog/product.tpl" source-language="en_US_POSIX" target-language="en-US" datatype="plaintext">
+    <body>
+      <trans-unit id="a38a66d53a6edc2d8e37bb36b45814ee">
+        <source>Show product</source>
+        <target>Show product</target>
+        <note>Context:
+File: home/ubuntu/workspace/PrestaShop/src/PrestaShopBundle/Tests/resources/themes/fake-theme/templates/catalog/product.tpl:1</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Translation/Extractor/Util/Flattenizer.php
+++ b/Translation/Extractor/Util/Flattenizer.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * 2007-2016 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2015 PrestaShop SA
+ * @license   http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\TranslationToolsBundle\Translation\Extractor\Util;
+
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Finder\Finder;
+
+/**
+ * This class have only one thing to do, transform:.
+ *
+ * ├── Admin
+ * │   └── Catalog
+ * │        ├── Feature.en-US.xlf
+ * │        ├── Help.en-US.xlf
+ * │        └── Notification.en-US.xlf
+ * └── Shop
+ *      └── PDF.en-US.xlf
+ * 
+ *
+ * Into:
+ *
+ * ├── AdminCatalogFeature.en-US.xlf
+ * ├── AdminCatalogHelp.en-US.xlf
+ * ├── AdminCatalogNotification.en-US.xlf
+ * └── ShopPDF.en-US.xlf
+ */
+class Flattenizer
+{
+    /**
+     * @input string $inputPath Path of directory to flattenize
+     * @input string $outPath Location of flattenized files newly created
+     */
+    public static function flatten($inputPath, $outputPath)
+    {
+        $finder = new Finder();
+        $filesystem = new Filesystem();
+
+        $filesystem->remove($outputPath)->mkdir($outputPath);
+
+        foreach ($finder->in($inputPath) as $file) {
+            $flatName = preg_replace('/\//', '', $file->getRelativePath()).$file->getFilename();
+            $filesystem->copy($file->getRealpath(), $outputPath.'/'.$flatName);
+        }
+    }
+}

--- a/Translation/Extractor/Util/Flattenizer.php
+++ b/Translation/Extractor/Util/Flattenizer.php
@@ -31,16 +31,17 @@ use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 
 /**
- * This class have only one thing to do, transform:.
+ * This class have only one thing to do, transform:
  *
- * ├── Admin
- * │   └── Catalog
- * │        ├── Feature.en-US.xlf
- * │        ├── Help.en-US.xlf
- * │        └── Notification.en-US.xlf
- * └── Shop
- *      └── PDF.en-US.xlf
- * 
+ * en-US
+ *   ├── Admin
+ *   │   └── Catalog
+ *   │        ├── Feature.xlf
+ *   │        ├── Help.xlf
+ *   │        └── Notification.xlf
+ *   └── Shop
+ *        └── PDF.xlf
+ *
  *
  * Into:
  *
@@ -54,17 +55,22 @@ class Flattenizer
     /**
      * @input string $inputPath Path of directory to flattenize
      * @input string $outPath Location of flattenized files newly created
+     * @input string $locale Selected locale for theses files.
      */
-    public static function flatten($inputPath, $outputPath)
+    public static function flatten($inputPath, $outputPath, $locale)
     {
         $finder = new Finder();
         $filesystem = new Filesystem();
 
-        $filesystem->remove($outputPath)->mkdir($outputPath);
+        $filesystem->remove($outputPath);
+        $filesystem->mkdir($outputPath);
 
-        foreach ($finder->in($inputPath) as $file) {
-            $flatName = preg_replace('/\//', '', $file->getRelativePath()).$file->getFilename();
+        foreach ($finder->in($inputPath)->files() as $file) {
+            $flatName = preg_replace('#\/#', '', $file->getRelativePath()).$file->getFilename();
+            $flatName = preg_replace('#\.xlf#', '.'.$locale.'.xlf', $flatName);
             $filesystem->copy($file->getRealpath(), $outputPath.'/'.$flatName);
         }
+
+        return true;
     }
 }


### PR DESCRIPTION
We need a flattenizer to retrieve the same format for both themes and common translation retrieved by TranslationTool application.

```
/**
 * This class have only one thing to do, transform:
 *
 * en-US
 *   ├── Admin
 *   │   └── Catalog
 *   │        ├── Feature.xlf
 *   │        ├── Help.xlf
 *   │        └── Notification.xlf
 *   └── Shop
 *        └── PDF.xlf
 *
 *
 * Into:
 *
 * ├── AdminCatalogFeature.en-US.xlf
 * ├── AdminCatalogHelp.en-US.xlf
 * ├── AdminCatalogNotification.en-US.xlf
 * └── ShopPDF.en-US.xlf
 */
```