### PR TITLE
Fix extra backslash when parsing smarty files

### DIFF
--- a/Translation/Extractor/SmartyExtractor.php
+++ b/Translation/Extractor/SmartyExtractor.php
@@ -74,10 +74,11 @@ class SmartyExtractor extends AbstractFileExtractor implements ExtractorInterfac
     {
         foreach ($this->smartyCompiler->setTemplateFile($resource->getPathname())->getTranslationTags() as $translation) {
             $domain = $this->resolveDomain(isset($translation['tag']['d']) ? $translation['tag']['d'] : null);
+            $string = stripslashes($translation['tag']['s']);
 
-            $catalogue->set($this->prefix.$translation['tag']['s'], $translation['tag']['s'], $domain);
+            $catalogue->set($this->prefix.$string, $string, $domain);
             $catalogue->setMetadata(
-                $this->prefix.$translation['tag']['s'],
+                $this->prefix.$string,
                 [
                     'line' => $translation['line'],
                     'file' => $translation['template'],


### PR DESCRIPTION
Before:
![before](https://cloud.githubusercontent.com/assets/2203436/18128513/65fcb6fe-6f86-11e6-80d1-1ac7a6fbba5e.png)

After:
![after](https://cloud.githubusercontent.com/assets/2203436/18128515/69422100-6f86-11e6-84e4-40c24b59b5d9.png)

Without it, the front office has some string untranslated.