### PR TITLE
Always use realpath on root_dir

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -11,15 +11,15 @@ services:
             - "Smarty_Internal_Templatelexer"
             - "Smarty_Internal_Templateparser"
             - "@prestashop.smarty"
-            
+
     prestashop.translation.parser.crowdin_php_parser:
         class: PrestaShop\TranslationToolsBundle\Translation\Parser\CrowdinPhpParser
-            
+
     prestashop.translation.manager.original_string_manager:
         class: PrestaShop\TranslationToolsBundle\Translation\Manager\OriginalStringManager
         arguments:
             - "@prestashop.translation.parser.crowdin_php_parser"
-            
+
     prestashop.translation.manager.translation_manager:
         class: PrestaShop\TranslationToolsBundle\Translation\Manager\TranslationManager
         arguments:
@@ -30,7 +30,7 @@ services:
         arguments:
             - "@prestashop.translation.parser.crowdin_php_parser"
             - "@prestashop.translation.manager.original_string_manager"
-        
+
     prestashop.translation.chainextractor:
         class:  PrestaShop\TranslationToolsBundle\Translation\Extractor\ChainExtractor
 


### PR DESCRIPTION
Example:
```bash
php bin/console prestashop:translation:extract ../source/develop/.t9n.yml
```
The `root_dir` is `../source/develop` when it must be `/home/got/projects/prestashop/source/develop`