### PR TITLE
Improve extraction of wordings from Smarty templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 vendor/
 phpunit.xml
 build/
+Tests/cache/*

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -4,6 +4,8 @@ services:
         calls:
             - [setCompileDir, ['%kernel.cache_dir%/smarty']]
             - [forceCompile, [true]]
+            - [registerResource, ['module', "@prestashop.translation.helper.smarty.smarty_resource_module"]]
+            - [registerResource, ['parent', "@prestashop.translation.helper.smarty.smarty_resource_parent"]]
 
     prestashop.compiler.smarty.template:
         class: PrestaShop\TranslationToolsBundle\Translation\Compiler\Smarty\TranslationTemplateCompiler
@@ -11,6 +13,12 @@ services:
             - "Smarty_Internal_Templatelexer"
             - "Smarty_Internal_Templateparser"
             - "@prestashop.smarty"
+
+    prestashop.translation.helper.smarty.smarty_resource_module:
+        class: PrestaShop\TranslationToolsBundle\Translation\Helper\Smarty\SmartyResourceModule
+
+    prestashop.translation.helper.smarty.smarty_resource_parent:
+        class: PrestaShop\TranslationToolsBundle\Translation\Helper\Smarty\SmartyResourceParent
 
     prestashop.translation.parser.crowdin_php_parser:
         class: PrestaShop\TranslationToolsBundle\Translation\Parser\CrowdinPhpParser

--- a/Tests/PhpUnit/TestCase.php
+++ b/Tests/PhpUnit/TestCase.php
@@ -5,6 +5,7 @@ namespace PrestaShop\TranslationToolsBundle\Tests\PhpUnit;
 use ReflectionProperty;
 use ReflectionMethod;
 use PHPUnit_Framework_TestCase as PhpUnitTestCase;
+use Symfony\Component\Translation\MessageCatalogue;
 
 class TestCase extends PhpUnitTestCase
 {
@@ -66,5 +67,31 @@ class TestCase extends PhpUnitTestCase
     protected function getResource($resourceName)
     {
         return realpath(__DIR__.'/../resources/'.$resourceName);
+    }
+
+    /**
+     * @param $messageCatalogue
+     * @param array[] $expected
+     */
+    protected function verifyCatalogue(MessageCatalogue $messageCatalogue, $expected)
+    {
+        $domains = $messageCatalogue->getDomains();
+
+        foreach ($expected as $expectedDomain => $expectedStrings) {
+            // the domain should be defined
+            $this->assertContains(
+                $expectedDomain,
+                $domains,
+                sprintf('Domain "%s" is not defined in %s', $expectedDomain, print_r($domains, true))
+            );
+
+            // all strings should be defined in the appropriate domain
+            foreach ($expectedStrings as $string) {
+                $this->assertTrue(
+                    $messageCatalogue->defines($string, $expectedDomain),
+                    sprintf('"%s" not found in %s', $string, $expectedDomain)
+                );
+            }
+        }
     }
 }

--- a/Tests/Translation/Extractor/PhpExtractorTest.php
+++ b/Tests/Translation/Extractor/PhpExtractorTest.php
@@ -106,24 +106,7 @@ class PhpExtractorTest extends TestCase
     {
         $messageCatalogue = $this->buildMessageCatalogue($file);
 
-        $domains = $messageCatalogue->getDomains();
-
-        foreach ($expected as $expectedDomain => $expectedStrings) {
-            // the domain should be defined
-            $this->assertContains(
-                $expectedDomain,
-                $domains,
-                sprintf('Domain "%s" is not defined in %s', $expectedDomain, print_r($domains, true))
-            );
-
-            // all strings should be defined in the appropriate domain
-            foreach ($expectedStrings as $string) {
-                $this->assertTrue(
-                    $messageCatalogue->defines($string, $expectedDomain),
-                    sprintf('"%s" not found in %s', $string, $expectedDomain)
-                );
-            }
-        }
+        $this->verifyCatalogue($messageCatalogue, $expected);
     }
 
     public function provideFormTranslationFixtures()
@@ -201,4 +184,5 @@ class PhpExtractorTest extends TestCase
 
         return $messageCatalogue;
     }
+
 }

--- a/Tests/Translation/Extractor/SmartyExtractorTest.php
+++ b/Tests/Translation/Extractor/SmartyExtractorTest.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * 2007-2018 PrestaShop
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\TranslationToolsBundle\Tests\Translation\Extractor;
+
+use PrestaShop\TranslationToolsBundle\Smarty;
+use PrestaShop\TranslationToolsBundle\Tests\PhpUnit\TestCase;
+use PrestaShop\TranslationToolsBundle\Translation\Compiler\Smarty\TranslationTemplateCompiler;
+use PrestaShop\TranslationToolsBundle\Translation\Extractor\SmartyExtractor;
+use PrestaShop\TranslationToolsBundle\Translation\Helper\Smarty\SmartyResourceModule;
+use PrestaShop\TranslationToolsBundle\Translation\Helper\Smarty\SmartyResourceParent;
+use Smarty_Internal_Templatelexer;
+use Smarty_Internal_Templateparser;
+use Symfony\Component\Translation\MessageCatalogue;
+
+class SmartyExtractorTest extends TestCase
+{
+    /**
+     * @var SmartyExtractor
+     */
+    private $instance;
+
+    /**
+     * @inheritDoc
+     */
+    protected function setUp()
+    {
+        $smarty = new Smarty();
+        $smarty
+            ->setCompileDir(__DIR__ . '/../../cache/smarty')
+            ->setForceCompile(true);
+
+        $smarty->registerResource('module', new SmartyResourceModule());
+        $smarty->registerResource('parent', new SmartyResourceParent());
+
+        $compiler = new TranslationTemplateCompiler(
+            Smarty_Internal_Templatelexer::class,
+            Smarty_Internal_Templateparser::class,
+            $smarty
+        );
+
+        $this->instance = new SmartyExtractor($compiler);
+    }
+
+    public function testExtractWithDomain()
+    {
+        $messageCatalogue = $this->buildMessageCatalogue('payment_return.tpl');
+
+        $expected = [
+            'Modules.Wirepayment.Shop' => [
+                'Your order on %s is complete.',
+                'Please send us a bank wire with:',
+                'Please specify your order reference %s in the bankwire description.',
+                'We\'ve also sent you this information by e-mail.',
+                'Your order will be sent as soon as we receive payment.',
+                'If you have questions, comments or concerns, please contact our [1]expert customer support team[/1].',
+                'We noticed a problem with your order. If you think this is an error, feel free to contact our [1]expert customer support team[/1].',
+            ]
+        ];
+
+        $this->verifyCatalogue($messageCatalogue, $expected);
+    }
+
+    public function testExtractWithoutDomain()
+    {
+        $messageCatalogue = $this->buildMessageCatalogue('oldsystem.tpl');
+
+        $this->assertEmpty($messageCatalogue->getDomains());
+    }
+
+    /**
+     * @param $fixtureResource
+     *
+     * @return MessageCatalogue
+     */
+    private function buildMessageCatalogue($fixtureResource)
+    {
+        $messageCatalogue = new MessageCatalogue('en');
+        $this->instance->extract($this->getResource($fixtureResource), $messageCatalogue);
+
+        return $messageCatalogue;
+    }
+
+    /**
+     * @param string $resourceName
+     *
+     * @return string
+     */
+    protected function getResource($resourceName)
+    {
+        return parent::getResource('fixtures/smarty/'.$resourceName);
+    }
+}

--- a/Tests/resources/fixtures/smarty/oldsystem.tpl
+++ b/Tests/resources/fixtures/smarty/oldsystem.tpl
@@ -1,0 +1,94 @@
+{*
+* 2007-2018 PrestaShop
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+* @author    PrestaShop SA <contact@prestashop.com>
+* @copyright 2007-2018 PrestaShop SA
+* @license   http://addons.prestashop.com/en/content/12-terms-and-conditions-of-use
+* International Registered Trademark & Property of PrestaShop SA
+*}
+
+<div id="psthemecusto">
+  <div class="panel col-lg-12">
+    <div class="panel-heading">
+      {l s='Advanced Customization' mod='ps_themecusto'}
+    </div>
+    <div class="row">
+      <div class="col-ld-12">
+        <p>{l s='You can edit your theme sheet by using the Parent/Child theme feature' mod='ps_themecusto'}:</p>
+      </div>
+      {if $is_ps_ready}
+        <div class="alert alert-warning" role="alert">
+          <b>{l s='Advanced use only.' mod='ps_themecusto'}</b>
+          <p class="alert-text">
+            {l s='Support team might not be able to assist you on issues created by your own child theme.' mod='ps_themecusto'}
+          </p>
+        </div>
+      {/if}
+      <div class="col-ld-12 steps">
+        <div class="col-lg-3">
+          <div class="col-lg-12 center-img">
+            <img src="{$images}download.png"/>
+          </div>
+          <b>1 - {l s='Download your current theme' mod='ps_themecusto'}</b>
+          <div class="col-lg-12">
+            <p>{l s='You picked a theme but still want to bring some specific adjustments? Get a child theme, it will allow you to keep the parts you want and customize the others!' mod='ps_themecusto'}</p>
+          </div>
+        </div>
+        <div class="col-lg-3 col-lg-push-1">
+          <div class="col-lg-12 center-img">
+            <img src="{$images}edit.png"/>
+          </div>
+          <b>2 - {l s='Edit your child theme' mod='ps_themecusto'}</b>
+          <div class="col-lg-12">
+            <p>{l s='Once the child theme created, next step is simple: apply the changes you want within the desired files, it will handle the customization part while keeping the parent theme’s look and functionality.' mod='ps_themecusto'}</p>
+          </div>
+        </div>
+        <div class="col-lg-3 col-lg-push-2">
+          <div class="col-lg-12 center-img">
+            <img src="{$images}reupload.png"/>
+          </div>
+          <b>3 - {l s='Upload your child theme' mod='ps_themecusto'}</b>
+          <div class="col-lg-12">
+            <p>{l s='As you only bring modification to the child theme, you can upgrade the parent theme easily, without losing your customization.' mod='ps_themecusto'}</p>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="row row-buttons">
+      <div class="col-lg-3">
+        <div class="alert alert-danger download_child_theme_error" role="alert">
+          <b>{l s='An error occurred' mod='ps_themecusto'}</b>
+          <p class="alert-text">{l s='Please check that you have the rights to write to the folders /app/cache/ and /themes/' mod='ps_themecusto'}</p>
+        </div>
+        <div class="btn btn-primary btn-lg btn-block" rel="noopener" id="download_child_theme">
+          {l s='Download theme' mod='ps_themecusto'}
+        </div>
+        <div class="btn btn-primary btn-lg btn-block js-loader" rel="noopener" >
+          {l s='Downloading' mod='ps_themecusto'}<div class="loader"></div>
+        </div>
+      </div>
+      <div class="col-lg-3 col-lg-push-1">
+        <a href="https://devdocs.prestashop.com/1.7/themes/reference/template_inheritance/parent_child_feature/" class="link-child btn btn-outline-secondary btn-lg btn-block" rel="noopener" target="_blank">{l s='How to use parents/child themes' mod='ps_themecusto'} <i class="icon-external-link"></i></a>
+      </div>
+      <div class="col-lg-3 col-lg-push-2">
+        <a href="#" class="btn btn-primary btn-lg btn-block" rel="noopener" data-toggle="modal" data-target="#upload-child-modal" >{l s='Upload child theme' mod='ps_themecusto'}</a>
+      </div>
+    </div>
+    <div class="alert alert-info col-lg-12" role="alert">
+      <b>{l s='Information' mod='ps_themecusto'}</b>
+      {if $is_ps_ready}
+        <p class="alert-text">{l s='By using this method you can only override the CSS of your theme.' mod='ps_themecusto'}</p>
+      {else}
+        <p class="alert-text">{l s='By using this method you can override the CSS and html of your theme, and add analytics tags.' mod='ps_themecusto'}</p>
+      {/if}
+      <p class="alert-text">{l s='Once uploaded, the child theme will be available in your Theme & Logo section' mod='ps_themecusto'}</p>
+    </div>
+    {include file="./elem/modal.tpl"}
+  </div>
+</div>

--- a/Tests/resources/fixtures/smarty/payment_return.tpl
+++ b/Tests/resources/fixtures/smarty/payment_return.tpl
@@ -1,0 +1,45 @@
+{*
+* 2007-2015 PrestaShop
+*
+* NOTICE OF LICENSE
+*
+* This source file is subject to the Academic Free License (AFL 3.0)
+* that is bundled with this package in the file LICENSE.txt.
+* It is also available through the world-wide-web at this URL:
+* http://opensource.org/licenses/afl-3.0.php
+* If you did not receive a copy of the license and are unable to
+* obtain it through the world-wide-web, please send an email
+* to license@prestashop.com so we can send you a copy immediately.
+*
+* DISCLAIMER
+*
+* Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+* versions in the future. If you wish to customize PrestaShop for your
+* needs please refer to http://www.prestashop.com for more information.
+*
+*  @author PrestaShop SA <contact@prestashop.com>
+*  @copyright  2007-2015 PrestaShop SA
+*  @license    http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+*  International Registered Trademark & Property of PrestaShop SA
+*}
+
+{if $status == 'ok'}
+    <p>
+      {l s='Your order on %s is complete.' sprintf=[$shop_name] d='Modules.Wirepayment.Shop'}<br/>
+      {l s='Please send us a bank wire with:' d='Modules.Wirepayment.Shop'}
+    </p>
+    {include file='module:ps_wirepayment/views/templates/hook/_partials/payment_infos.tpl'}
+
+    <p>
+      {l s='Please specify your order reference %s in the bankwire description.' sprintf=[$reference] d='Modules.Wirepayment.Shop'}<br/>
+      {l s='We\'ve also sent you this information by e-mail.' d='Modules.Wirepayment.Shop'}
+    </p>
+    <strong>{l s='Your order will be sent as soon as we receive payment.' d='Modules.Wirepayment.Shop'}</strong>
+    <p>
+      {l s='If you have questions, comments or concerns, please contact our [1]expert customer support team[/1].' d='Modules.Wirepayment.Shop' sprintf=['[1]' => "<a href='{$contact_url}'>", '[/1]' => '</a>']}
+    </p>
+{else}
+    <p class="warning">
+      {l s='We noticed a problem with your order. If you think this is an error, feel free to contact our [1]expert customer support team[/1].' d='Modules.Wirepayment.Shop' sprintf=['[1]' => "<a href='{$contact_url}'>", '[/1]' => '</a>']}
+    </p>
+{/if}

--- a/Translation/Extractor/SmartyExtractor.php
+++ b/Translation/Extractor/SmartyExtractor.php
@@ -72,7 +72,15 @@ class SmartyExtractor extends AbstractFileExtractor implements ExtractorInterfac
      */
     protected function extractFromFile(SplFileInfo $resource, MessageCatalogue $catalogue)
     {
-        foreach ($this->smartyCompiler->setTemplateFile($resource->getPathname())->getTranslationTags() as $translation) {
+        $compiler = $this->smartyCompiler->setTemplateFile($resource->getPathname());
+        $translationTags = $compiler->getTranslationTags();
+
+        foreach ($translationTags as $translation) {
+            // do not include "old styled" translations in the catalogue
+            if (isset($translation['tag']['mod'])) {
+                continue;
+            }
+
             $domain = $this->resolveDomain(isset($translation['tag']['d']) ? $translation['tag']['d'] : null);
             $string = stripslashes($translation['tag']['s']);
 

--- a/Translation/Helper/Smarty/SmartyResourceModule.php
+++ b/Translation/Helper/Smarty/SmartyResourceModule.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * 2007-2018 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\TranslationToolsBundle\Translation\Helper\Smarty;
+
+/**
+ * Stub to support "module" as a resource in smarty files
+ */
+class SmartyResourceModule extends \Smarty_Resource_Custom
+{
+    /**
+     * Fetch a template.
+     *
+     * @param string $name template name
+     * @param string $source template source
+     * @param int $mtime template modification timestamp (epoch)
+     */
+    protected function fetch($name, &$source, &$mtime)
+    {
+        return;
+    }
+}

--- a/Translation/Helper/Smarty/SmartyResourceParent.php
+++ b/Translation/Helper/Smarty/SmartyResourceParent.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * 2007-2018 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/OSL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2018 PrestaShop SA
+ * @license   https://opensource.org/licenses/OSL-3.0 Open Software License (OSL 3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+
+namespace PrestaShop\TranslationToolsBundle\Translation\Helper\Smarty;
+
+/**
+ * Stub to support "parent" as a resource in smarty files
+ */
+class SmartyResourceParent extends \Smarty_Resource_Custom
+{
+    /**
+     * Fetch a template.
+     *
+     * @param string $name template name
+     * @param string $source template source
+     * @param int $mtime template modification timestamp (epoch)
+     */
+    protected function fetch($name, &$source, &$mtime)
+    {
+        return;
+    }
+}


### PR DESCRIPTION
- Automated tests
- Does not pollute the catalog by skipping wordings in old-style syntax
  (eg: 'mod="mymodule"')
- Doesn't crash and skip everything when using custom resource
  resolving