### PR TITLE
Handle read Xliff metadata when dumping files

### DIFF
--- a/Tests/Translation/Dumper/XliffFileDumperTest.php
+++ b/Tests/Translation/Dumper/XliffFileDumperTest.php
@@ -52,8 +52,8 @@ class XliffFileDumperTest extends TestCase
     public function getNoteProvider()
     {
         return [
-            ['Context:', [[]]],
-            ['Context:'.PHP_EOL.'File: file:0', [['file' => 'file', 'line' => '0']]],
+            ['', [[]]],
+            ['Line: 0', [['file' => 'file', 'line' => '0']]],
         ];
     }
 

--- a/Tests/resources/dump/en/messages.xlf
+++ b/Tests/resources/dump/en/messages.xlf
@@ -5,8 +5,7 @@
       <trans-unit id="8b04d5e3775d298e78455efc5ca404d5">
         <source>first</source>
         <target>first</target>
-        <note>Context:
-File: controllers/admin/AdminAccessController.php:6</note>
+        <note>Line: 6</note>
       </trans-unit>
     </body>
   </file>
@@ -15,8 +14,7 @@ File: controllers/admin/AdminAccessController.php:6</note>
       <trans-unit id="a9f0e61a137d86aa9db53465e0801612">
         <source>second</source>
         <target>second</target>
-        <note>Context:
-File: override/controllers/admin/AdminAccessController.php:6</note>
+        <note>Line: 6</note>
       </trans-unit>
     </body>
   </file>
@@ -25,8 +23,7 @@ File: override/controllers/admin/AdminAccessController.php:6</note>
       <trans-unit id="dd5c8bf51558ffcbe5007071908e9524">
         <source>third</source>
         <target>third</target>
-        <note>Context:
-File: classes/helper/Helper.php:6</note>
+        <note>Line: 6</note>
       </trans-unit>
     </body>
   </file>
@@ -35,8 +32,7 @@ File: classes/helper/Helper.php:6</note>
       <trans-unit id="c0759f2416498708841e7975566360ce">
         <source>fourth</source>
         <target>fourth</target>
-        <note>Context:
-File: themes/classic/modules/blockcart/modal.tpl:0</note>
+        <note>Line: 0</note>
       </trans-unit>
     </body>
   </file>
@@ -45,8 +41,7 @@ File: themes/classic/modules/blockcart/modal.tpl:0</note>
       <trans-unit id="0883a6520e6eb6c9304dcfb71034d053">
         <source>fifth</source>
         <target>fifth</target>
-        <note>Context:
-File: themes/classic/templates/catalog/category.tpl:0</note>
+        <note>Line: 0</note>
       </trans-unit>
     </body>
   </file>
@@ -55,8 +50,7 @@ File: themes/classic/templates/catalog/category.tpl:0</note>
       <trans-unit id="93c38fcf0d200be001335ef572650346">
         <source>sixth</source>
         <target>sixth</target>
-        <note>Context:
-File: override/classes/pdf/PDF.php:0</note>
+        <note>Line: 0</note>
       </trans-unit>
     </body>
   </file>
@@ -65,8 +59,7 @@ File: override/classes/pdf/PDF.php:0</note>
       <trans-unit id="5098d245aa911c02a50e276087c0b4a9">
         <source>seventh</source>
         <target>seventh</target>
-        <note>Context:
-File: none (skip):0</note>
+        <note>Line: 0</note>
       </trans-unit>
     </body>
   </file>

--- a/Tests/resources/sampleXliff.xlf
+++ b/Tests/resources/sampleXliff.xlf
@@ -5,8 +5,7 @@
       <trans-unit id="8b04d5e3775d298e78455efc5ca404d5">
         <source>first</source>
         <target>first</target>
-        <note>Context:
-File: controllers/admin/AdminAccessController.php:6</note>
+        <note>Line: 6</note>
       </trans-unit>
     </body>
   </file>
@@ -15,8 +14,7 @@ File: controllers/admin/AdminAccessController.php:6</note>
       <trans-unit id="a9f0e61a137d86aa9db53465e0801612">
         <source>second</source>
         <target>second</target>
-        <note>Context:
-File: override/controllers/admin/AdminAccessController.php:6</note>
+        <note>Line: 6</note>
       </trans-unit>
     </body>
   </file>
@@ -25,8 +23,7 @@ File: override/controllers/admin/AdminAccessController.php:6</note>
       <trans-unit id="dd5c8bf51558ffcbe5007071908e9524">
         <source>third</source>
         <target>third</target>
-        <note>Context:
-File: classes/helper/Helper.php:6</note>
+        <note>Line: 6</note>
       </trans-unit>
     </body>
   </file>
@@ -35,8 +32,7 @@ File: classes/helper/Helper.php:6</note>
       <trans-unit id="c0759f2416498708841e7975566360ce">
         <source>fourth</source>
         <target>fourth</target>
-        <note>Context:
-File: themes/classic/modules/blockcart/modal.tpl:0</note>
+        <note>Line: 0</note>
       </trans-unit>
     </body>
   </file>
@@ -45,8 +41,7 @@ File: themes/classic/modules/blockcart/modal.tpl:0</note>
       <trans-unit id="0883a6520e6eb6c9304dcfb71034d053">
         <source>fifth</source>
         <target>fifth</target>
-        <note>Context:
-File: themes/classic/templates/catalog/category.tpl:0</note>
+        <note>Line: 0</note>
       </trans-unit>
     </body>
   </file>
@@ -55,8 +50,7 @@ File: themes/classic/templates/catalog/category.tpl:0</note>
       <trans-unit id="93c38fcf0d200be001335ef572650346">
         <source>sixth</source>
         <target>sixth</target>
-        <note>Context:
-File: override/classes/pdf/PDF.php:0</note>
+        <note>Line: 0</note>
       </trans-unit>
     </body>
   </file>
@@ -65,8 +59,7 @@ File: override/classes/pdf/PDF.php:0</note>
       <trans-unit id="5098d245aa911c02a50e276087c0b4a9">
         <source>seventh</source>
         <target>seventh</target>
-        <note>Context:
-File: none (skip):0</note>
+        <note>Line: 0</note>
       </trans-unit>
     </body>
   </file>

--- a/Translation/Dumper/XliffFileDumper.php
+++ b/Translation/Dumper/XliffFileDumper.php
@@ -125,21 +125,25 @@ class XliffFileDumper extends BaseXliffFileDumper
      */
     private function getNote($transMetadata)
     {
-        $context = 'Context:';
+        $notes = [];
 
         if (!empty($transMetadata['file'])) {
-            $context .= PHP_EOL.'File: '.$transMetadata['file'];
 
             if (isset($transMetadata['line'])) {
-                $context .= ':'.$transMetadata['line'];
+                $notes['line'] = 'Line: '.$transMetadata['line'];
             }
 
             if (isset($transMetadata['comment'])) {
-                $context .= PHP_EOL.' Comment: '.$transMetadata['comment'];
+                $notes['comment'] = 'Comment: '.$transMetadata['comment'];
             }
         }
 
-        return $context;
+        if (empty($notes) && isset($transMetadata['notes'][0]['content'])) {
+            // use notes loaded from xliff file
+            return $transMetadata['notes'][0]['content'];
+        }
+
+        return implode(PHP_EOL, $notes);
     }
 
     /**

--- a/Translation/Dumper/XliffFileDumper.php
+++ b/Translation/Dumper/XliffFileDumper.php
@@ -96,10 +96,20 @@ class XliffFileDumper extends BaseXliffFileDumper
         foreach ($messages->all($domain) as $source => $target) {
             if (!empty($source)) {
                 $metadata = $messages->getMetadata($source, $domain);
+
+                /**
+                 * Handle original file information from xliff file.
+                 * This is needed if at least part of the catalogue was read from xliff files
+                 */
+                if (is_array($metadata['file']) && !empty($metadata['file']['original'])) {
+                    $metadata['file'] = $metadata['file']['original'];
+                }
+
                 $metadata['file'] = Configuration::getRelativePath(
                     $metadata['file'],
                     !empty($options['root_dir']) ? realpath($options['root_dir']) : false
                 );
+
                 $xliffBuilder->addFile($metadata['file'], $defaultLocale, $messages->getLocale());
                 $xliffBuilder->addTransUnit($metadata['file'], $source, $target, $this->getNote($metadata));
             }


### PR DESCRIPTION
When trying to dump a catalog that was read from an Xliff file using XliffFileLoader, the catalog was missing the "original file" metadata, making it impossible to write the same file again due to missing information. This has been fixed in the loader:  https://github.com/symfony/symfony/pull/29148.

The catalog's "original file" metadata structure is different when read from an Xliff file and when parsed from source files using TranslationToolsBundle. This Pull Request provides support for the new metadata format as well as improving the `<note>` information by removing useless information.