### PR TITLE
Bug when having an include in the smarty

### DIFF
--- a/Translation/Compiler/Smarty/TranslationTemplateCompiler.php
+++ b/Translation/Compiler/Smarty/TranslationTemplateCompiler.php
@@ -100,6 +100,7 @@ class TranslationTemplateCompiler extends Smarty_Internal_SmartyTemplateCompiler
 
                 $this->parser->yy_accept();
             } catch (SmartyException $e) {
+                $this->parser->yy_accept();
             }
         }
 


### PR DESCRIPTION
Hello,

when trying to extract translations in the following file : 

```
<div id="_desktop_cart" class="ml-3">
  <div class="blockcart cart-preview {if $cart.products_count > 0}active{else}inactive{/if}" data-refresh-url="{$refresh_url}">
      <div class="dropdown">
          <button class="dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
              <div class="header">
                  {if $cart.products_count > 0}
                  <a rel="nofollow" href="{$cart_url}">
                      {/if}
                      {*<i class="fas fa-shopping-cart"></i>*}
                      <span class="d-none d-lg-inline">{l s='Cart' d='Shop.Theme.Actions'}</span>
                      <span class="cart-products-count small"><span class="number_pdt">{$cart.products_count}</span></span>
                      {if $cart.products_count > 0}
                  </a>
                  {/if}
              </div>
          </button>
          <div class="dropdown-menu" id="desktop_shopping_cart_dropdown" aria-labelledby="dropdownMenuButton">
              {if $cart.products_count > 0}
              <div class="toolbar-dropdown">
                  {foreach from=$cart.products item=product}
                      {include file='module:ps_shoppingcart/ps_shoppingcart-product-line.tpl' product=$product}
                  {/foreach}
                  <div class="toolbar-dropdown-group">
                      <div class="row">
                          {foreach from=$cart.subtotals item="subtotal"}
                              <div class="col-6">{$subtotal.label}</span></div>
                              <div class="col-6 text-right">{$subtotal.value}</div>
                          {/foreach}
                          <div class="col-6">{$cart.totals.total.label}</div>
                          <div class="col-6 text-right">{$cart.totals.total.value}</div>
                      </div>
                  </div>
              </div>
              <div class="toolbar-dropdown-total">
                  <a class="btn-checkout btn btn-primary" href="{$urls.pages.order}">{l s='Check Out' d='Shop.Theme.Actions'}</a>
                  <a class="btn-view btn btn-secondary" href="{$cart_url}">{l s='View cart' d='Shop.Theme.Actions'}</a>
              </div>
              {else}
              <p>{l s='Your cart is empy' d='Shop.Theme.Actions'}</p>
              {/if}
          </div>
      </div>
  </div>
</div>
```

All translations after the {include } directive where not found.

Adding the `$this->parser->yy_accept();` corrected this issue.

Regards,
David-Julian Buch