### PR TITLE
Infer module domain for old legacy modules

### DIFF
--- a/Tests/Translation/Extractor/SmartyExtractorTest.php
+++ b/Tests/Translation/Extractor/SmartyExtractorTest.php
@@ -69,7 +69,7 @@ class SmartyExtractorTest extends TestCase
         $messageCatalogue = $this->buildMessageCatalogue('oldsystem.tpl', SmartyExtractor::INCLUDE_EXTERNAL_MODULES);
 
         $expected = [
-            'Modules.Psthemecusto.Oldsystem' => [
+            'Modules.Themecusto.Oldsystem' => [
                 'Advanced Customization',
                 'You can edit your theme sheet by using the Parent/Child theme feature',
                 'Advanced use only.',

--- a/Tests/Translation/Extractor/SmartyExtractorTest.php
+++ b/Tests/Translation/Extractor/SmartyExtractorTest.php
@@ -69,7 +69,7 @@ class SmartyExtractorTest extends TestCase
         $messageCatalogue = $this->buildMessageCatalogue('oldsystem.tpl', SmartyExtractor::INCLUDE_EXTERNAL_MODULES);
 
         $expected = [
-            'Modules.Psthemecusto.oldsystem' => [
+            'Modules.Psthemecusto.Oldsystem' => [
                 'Advanced Customization',
                 'You can edit your theme sheet by using the Parent/Child theme feature',
                 'Advanced use only.',

--- a/Tests/Translation/Extractor/SmartyExtractorTest.php
+++ b/Tests/Translation/Extractor/SmartyExtractorTest.php
@@ -38,19 +38,6 @@ use Symfony\Component\Translation\MessageCatalogue;
 
 class SmartyExtractorTest extends TestCase
 {
-    /**
-     * @var SmartyExtractor
-     */
-    private $instance;
-
-    /**
-     * @inheritDoc
-     */
-    protected function setUp()
-    {
-
-    }
-
     public function testExtractWithDomain()
     {
         $messageCatalogue = $this->buildMessageCatalogue('payment_return.tpl');
@@ -82,7 +69,7 @@ class SmartyExtractorTest extends TestCase
         $messageCatalogue = $this->buildMessageCatalogue('oldsystem.tpl', SmartyExtractor::INCLUDE_EXTERNAL_MODULES);
 
         $expected = [
-            'messages' => [
+            'Modules.Psthemecusto.oldsystem' => [
                 'Advanced Customization',
                 'You can edit your theme sheet by using the Parent/Child theme feature',
                 'Advanced use only.',

--- a/Tests/Translation/Helper/DomainHelperTest.php
+++ b/Tests/Translation/Helper/DomainHelperTest.php
@@ -33,4 +33,56 @@ class DomainHelperTest extends TestCase
     {
         $this->assertEquals('admin.patate.douce', DomainHelper::getDomain('admin/patate/douce'));
     }
+
+    /**
+     * @param string $moduleName
+     * @param string $source
+     * @param string $expected
+     *
+     * @dataProvider provideModuleFromLegasySourceCases
+     */
+    public function testBuildModuleDomainFromLegacySource($moduleName, $source, $expected)
+    {
+        $this->assertSame($expected, DomainHelper::buildModuleDomainFromLegacySource($moduleName, $source));
+    }
+
+    /**
+     * @param string $moduleName
+     * @param bool $withDots
+     * @param string $expected
+     *
+     * @dataProvider provideModuleBaseDomainCases
+     */
+    public function testBuildModuleBaseDomain($moduleName, $withDots, $expected)
+    {
+        $this->assertSame($expected, DomainHelper::buildModuleBaseDomain($moduleName, $withDots));
+    }
+
+    public function provideModuleFromLegasySourceCases()
+    {
+        return [
+            ['ps_test', '', 'Modules.Test.Pstest'],
+            ['ps_test_Something', '', 'Modules.Testsomething.Pstestsomething'],
+            ['ps_test_ps_Something', '', 'Modules.Testpssomething.Pstestpssomething'],
+            ['ps_test_Ps_something', 'test_me', 'Modules.Testpssomething.Testme'],
+            ['ps_test_ps_something', 'test_Me', 'Modules.Testpssomething.Testme'],
+            ['ps_test_ps_something', 'testMe', 'Modules.Testpssomething.Testme'],
+            ['ps_test_ps_something', 'test-Me', 'Modules.Testpssomething.Test-me'],
+            ['ps_test_ps_something', 'test.Me', 'Modules.Testpssomething.Test.me'],
+        ];
+    }
+
+    public function provideModuleBaseDomainCases()
+    {
+        return [
+            ['ps_test', true, 'Modules.Test'],
+            ['ps_test_Something', true, 'Modules.Testsomething'],
+            ['ps_test_ps_Something', true, 'Modules.Testpssomething'],
+            ['ps_test_Ps_something', true, 'Modules.Testpssomething'],
+            ['ps_test', false, 'ModulesTest'],
+            ['ps_test_Something', false, 'ModulesTestsomething'],
+            ['ps_test_ps_Something', false, 'ModulesTestpssomething'],
+            ['ps_test_Ps_something', false, 'ModulesTestpssomething'],
+        ];
+    }
 }

--- a/Translation/Helper/DomainHelper.php
+++ b/Translation/Helper/DomainHelper.php
@@ -76,10 +76,10 @@ class DomainHelper
      */
     public static function buildModuleDomainFromLegacySource($moduleName, $sourceFileName)
     {
-        $transformedModuleName = ucfirst(str_replace('_', '', $moduleName));
+        $transformedModuleName = self::buildModuleDomainNameComponent($moduleName);
 
         if (empty($sourceFileName)) {
-            $source = $transformedModuleName;
+            $source = self::transformDomainComponent($moduleName);
         } else {
             $source = strtolower(basename($sourceFileName, '.tpl'));
 
@@ -88,11 +88,65 @@ class DomainHelper
                 $source = substr($source, 0, -10);
             }
 
-            $source = ucfirst(str_replace('_', '', $source));
+            $source = ucfirst(strtr($source, ['_' => '']));
         }
 
-        $extractedDomain = 'Modules.' . $transformedModuleName . '.' . $source;
+        $domain = 'Modules.' . $transformedModuleName . '.' . $source;
 
-        return $extractedDomain;
+        return $domain;
+    }
+
+    /**
+     * Returns the base domain for the provided module name
+     *
+     * @param string $moduleName
+     * @param bool $withDots True to use separating dots
+     *
+     * @return string
+     */
+    public static function buildModuleBaseDomain($moduleName, $withDots = false)
+    {
+        $domain = 'Modules';
+
+        if ($withDots) {
+            $domain .= '.';
+        }
+
+        $domain .= self::buildModuleDomainNameComponent($moduleName);
+
+        return $domain;
+    }
+
+    /**
+     * Transforms the module name to use in a domain
+     *
+     * @param string $moduleName
+     *
+     * @return string
+     */
+    private static function buildModuleDomainNameComponent($moduleName)
+    {
+        if ('ps_' === substr($moduleName, 0, 3)) {
+            $moduleName = substr($moduleName, 3);
+        }
+
+        return self::transformDomainComponent($moduleName);
+    }
+
+    /**
+     * Formats a domain component by removing unwanted characters
+     *
+     * @param string $component
+     *
+     * @return string
+     */
+    private static function transformDomainComponent($component)
+    {
+        return ucfirst(
+            strtr(
+                strtolower($component),
+                ['_' => '']
+            )
+        );
     }
 }

--- a/Translation/Helper/DomainHelper.php
+++ b/Translation/Helper/DomainHelper.php
@@ -65,4 +65,28 @@ class DomainHelper
     {
         return str_replace(DIRECTORY_SEPARATOR, '.', $exportPath);
     }
+
+    /**
+     * Builds a module domain name for the legacy system
+     *
+     * @param string $moduleName Name of the module (eg. ps_themecusto)
+     * @param string $sourceFileName Filename where the wording was found (eg. someFile.tpl)
+     *
+     * @return string The domain name (eg. Modules.Psthemecusto.somefile)
+     */
+    public static function buildModuleDomainFromLegacySource($moduleName, $sourceFileName)
+    {
+        $source = basename($sourceFileName, '.tpl');
+        if ('controller' == substr($source, -10, 10)) {
+            $source = substr($source, 0, -10);
+        }
+
+        $extractedDomain = sprintf(
+            'Modules.%s.%s',
+            ucfirst(str_replace('_', '', $moduleName)),
+            $source
+        );
+
+        return $extractedDomain;
+    }
 }

--- a/Translation/Helper/DomainHelper.php
+++ b/Translation/Helper/DomainHelper.php
@@ -76,16 +76,18 @@ class DomainHelper
      */
     public static function buildModuleDomainFromLegacySource($moduleName, $sourceFileName)
     {
-        $source = basename($sourceFileName, '.tpl');
+        $source = strtolower(basename($sourceFileName, '.tpl'));
         if ('controller' == substr($source, -10, 10)) {
             $source = substr($source, 0, -10);
         }
 
-        $extractedDomain = sprintf(
-            'Modules.%s.%s',
-            ucfirst(str_replace('_', '', $moduleName)),
-            $source
-        );
+        $transformedModuleName = ucfirst(str_replace('_', '', $moduleName));
+
+        $extractedDomain = 'Modules.' . $transformedModuleName;
+
+        if ($source !== $moduleName) {
+            $extractedDomain .= '.' . $source;
+        }
 
         return $extractedDomain;
     }

--- a/Translation/Helper/DomainHelper.php
+++ b/Translation/Helper/DomainHelper.php
@@ -77,6 +77,8 @@ class DomainHelper
     public static function buildModuleDomainFromLegacySource($moduleName, $sourceFileName)
     {
         $source = strtolower(basename($sourceFileName, '.tpl'));
+
+        // sourced from https://github.com/PrestaShop/PrestaShop/blob/1.6.1.x/classes/Translate.php#L174-L178
         if ('controller' == substr($source, -10, 10)) {
             $source = substr($source, 0, -10);
         }
@@ -85,7 +87,7 @@ class DomainHelper
 
         $extractedDomain = 'Modules.' . $transformedModuleName;
 
-        $extractedDomain .= '.' . ucfirst($source);
+        $extractedDomain .= '.' . ucfirst(str_replace('_', '', $source));
 
         return $extractedDomain;
     }

--- a/Translation/Helper/DomainHelper.php
+++ b/Translation/Helper/DomainHelper.php
@@ -85,9 +85,7 @@ class DomainHelper
 
         $extractedDomain = 'Modules.' . $transformedModuleName;
 
-        if ($source !== $moduleName) {
-            $extractedDomain .= '.' . ucfirst($source);
-        }
+        $extractedDomain .= '.' . ucfirst($source);
 
         return $extractedDomain;
     }

--- a/Translation/Helper/DomainHelper.php
+++ b/Translation/Helper/DomainHelper.php
@@ -76,18 +76,22 @@ class DomainHelper
      */
     public static function buildModuleDomainFromLegacySource($moduleName, $sourceFileName)
     {
-        $source = strtolower(basename($sourceFileName, '.tpl'));
-
-        // sourced from https://github.com/PrestaShop/PrestaShop/blob/1.6.1.x/classes/Translate.php#L174-L178
-        if ('controller' == substr($source, -10, 10)) {
-            $source = substr($source, 0, -10);
-        }
-
         $transformedModuleName = ucfirst(str_replace('_', '', $moduleName));
 
-        $extractedDomain = 'Modules.' . $transformedModuleName;
+        if (empty($sourceFileName)) {
+            $source = $transformedModuleName;
+        } else {
+            $source = strtolower(basename($sourceFileName, '.tpl'));
 
-        $extractedDomain .= '.' . ucfirst(str_replace('_', '', $source));
+            // sourced from https://github.com/PrestaShop/PrestaShop/blob/1.6.1.x/classes/Translate.php#L174-L178
+            if ('controller' == substr($source, -10, 10)) {
+                $source = substr($source, 0, -10);
+            }
+
+            $source = ucfirst(str_replace('_', '', $source));
+        }
+
+        $extractedDomain = 'Modules.' . $transformedModuleName . '.' . $source;
 
         return $extractedDomain;
     }

--- a/Translation/Helper/DomainHelper.php
+++ b/Translation/Helper/DomainHelper.php
@@ -86,7 +86,7 @@ class DomainHelper
         $extractedDomain = 'Modules.' . $transformedModuleName;
 
         if ($source !== $moduleName) {
-            $extractedDomain .= '.' . $source;
+            $extractedDomain .= '.' . ucfirst($source);
         }
 
         return $extractedDomain;


### PR DESCRIPTION
This change reverse-engineers the module domain for legacy modules using its name and the source file name and stores discovered wordings in that domain instead of "messages".

For example, for a module named "my_module", any wordings found in `my_module.php` will be assigned to `Modules.Mymodule.Mymodule` (read the commit message in https://github.com/PrestaShop/TranslationToolsBundle/pull/59/commits/8fa9a86232efb51ddf73147a41f81df3123d1785 to learn why), while wordings found in `some_file.tpl` will be assigned to `Modules.Mymodule.Somefile`