### PR TITLE
Add test for extracting wordings with no domain

### DIFF
--- a/Tests/Translation/Extractor/PhpExtractorTest.php
+++ b/Tests/Translation/Extractor/PhpExtractorTest.php
@@ -42,11 +42,19 @@ class PhpExtractorTest extends TestCase
         $this->assertTrue($messageCatalogue->defines('This is how symfony does it', 'admin.product.help'));
     }
 
-    public function testItInterpolatesDomainVariables()
+    public function testItExtractsTransWithoutDomain()
     {
         $messageCatalogue = $this->buildMessageCatalogue('fixtures/TestController.php');
 
+        $this->assertTrue($messageCatalogue->defines('Look, no domain', 'messages'));
+        $this->assertTrue($messageCatalogue->defines('It works with no domain and with parameters', 'messages'));
+    }
+
+    public function testItInterpolatesDomainVariables()
+    {
         $this->markTestIncomplete("The extractor doesn't know how to interpolate variables yet");
+
+        $messageCatalogue = $this->buildMessageCatalogue('fixtures/TestController.php');
 
         $this->assertTrue($messageCatalogue->defines('Bar', 'admin.product.plop'));
     }

--- a/Tests/resources/fixtures/TestController.php
+++ b/Tests/resources/fixtures/TestController.php
@@ -32,6 +32,15 @@ class TestController
             'Look, no parameters',
             'admin.product.help'
         );
+
+        $this->trans(
+            'Look, no domain'
+        );
+
+        $this->trans(
+            'It works with no domain and with parameters',
+            []
+        );
     }
 
     public function barAction()


### PR DESCRIPTION
Add missing test validating that calls to `trans` with no domain are correctly put in the "messages" domain.