### PR TITLE
Handle weird node parsing

### DIFF
--- a/Tests/resources/fixtures/TestController.php
+++ b/Tests/resources/fixtures/TestController.php
@@ -11,6 +11,8 @@ class TestController
 
     public function productAction()
     {
+        $useStaticLoader = PHP_VERSION_ID >= 50600 && !defined('HHVM_VERSION') && (!function_exists('zend_loader_file_encoded') || !zend_loader_file_encoded());
+
         $this->trans('Fingers', [], 'admin.product.help');
     }
 

--- a/Translation/Extractor/Visitor/Translation/ExplicitTranslationCall.php
+++ b/Translation/Extractor/Visitor/Translation/ExplicitTranslationCall.php
@@ -21,7 +21,7 @@ class ExplicitTranslationCall extends AbstractTranslationNodeVisitor
      */
     public function extractFrom(Node $node)
     {
-        if (!$this->appliesFor($node)) {
+        if (empty($node->args) || !$this->appliesFor($node)) {
             return [];
         }
 


### PR DESCRIPTION
The following payload is badly parsed and causes catalog extraction to fail:
```
        $useStaticLoader = PHP_VERSION_ID >= 50600 && !defined('HHVM_VERSION') && (!function_exists('zend_loader_file_encoded') || !zend_loader_file_encoded());
```

I added it to the test cases and added the fix.