### PR TITLE
Remove authors from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,20 +4,6 @@
   "keywords": ["translation", "parser", "prestashop"],
   "license": "MIT",
   "type": "bundle",
-  "authors": [
-    {
-      "name": "Mickaël Andrieu",
-      "email": "andrieu.travail@gmail.com"
-    },
-    {
-      "name": "Nawo Mbechezi",
-      "email": "mlanawo.mbechezi@ikimea.com"
-    },
-    {
-      "name": "Jérémie Tabet",
-      "email": "master@jeremietabet.com"
-    }
-  ],
   "config": {
     "sort-packages": true
   },


### PR DESCRIPTION
The 3 people listed in this repository are no longer working on this project.

We should remove them from the composer.json because
- they might receive emails for help/support although they probably don't want to (because they are not involved anymore)
- it carries wrong informations to people using the package

Shall we put a generic PrestaShop email address as author instead ?