### PR TITLE
Add test cases for $this->trans() in TranslatorAwareType

### DIFF
--- a/Tests/Translation/Extractor/PhpExtractorTest.php
+++ b/Tests/Translation/Extractor/PhpExtractorTest.php
@@ -143,6 +143,8 @@ class PhpExtractorTest extends TestCase
                 'file' => 'fixtures/TestFormChoicesTranslatorAware.php',
                 'expected' => [
                     'Install' => [
+                        "Some %foo% wording",
+                        "-- Please choose your main activity --",
                         "Animals and Pets",
                         "Art and Culture",
                         "Babies",

--- a/Tests/resources/fixtures/TestFormChoicesTranslatorAware.php
+++ b/Tests/resources/fixtures/TestFormChoicesTranslatorAware.php
@@ -53,6 +53,8 @@ class PreferencesType extends TranslatorAwareType
         $configuration = $this->getConfiguration();
         $isSslEnabled = $configuration->getBoolean('PS_SSL_ENABLED');
 
+        $test = $this->trans("Some %foo% wording", 'Install', ["%foo%" => "random"]);
+
         if ($this->isSecure) {
             $builder->add('enable_ssl', SwitchType::class);
         }


### PR DESCRIPTION

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | `$this->trans()` in TranslatorAwareType inverses the order of the 2nd and 3rd parameters. This PR adds tests to verify that these wordings are being extracted as expected.
| Type?         | tests
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | ~
| How to test?  | Verified by tests

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
