### PR TITLE
Make services public

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,4 +1,6 @@
 services:
+    _defaults:
+        public: true
     prestashop.smarty:
         class: PrestaShop\TranslationToolsBundle\Smarty
         calls:


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | To be able to use the declared services with symfony 4.4, they must be declared public
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| How to test?      | I don't think this is really testable, tests should be green at least
| Possible impacts? | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
