### PR TITLE
Add a Symfony integration test

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -40,6 +40,9 @@ jobs:
     - name: PHP CS Fixer
       run: ./vendor/bin/php-cs-fixer fix --dry-run
 
+    - name: Symfony Integration
+      run: php ./Tests/SymfonyIntegration/run.php
+
     - name: Upload coverage results to Coveralls
       if: matrix.php-versions == '7.4'
       env:

--- a/Tests/SymfonyIntegration/AppKernel.php
+++ b/Tests/SymfonyIntegration/AppKernel.php
@@ -1,7 +1,7 @@
 <?php
 
-use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\HttpKernel\Kernel;
 
 /**
  * Appkernel for tests
@@ -15,11 +15,11 @@ class AppKernel extends Kernel
     {
         date_default_timezone_set('UTC');
 
-        $bundles = array(
+        $bundles = [
             new Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
             new Symfony\Bundle\TwigBundle\TwigBundle(),
             new PrestaShop\TranslationToolsBundle\TranslationToolsBundle(),
-        );
+        ];
 
         return $bundles;
     }

--- a/Tests/SymfonyIntegration/AppKernel.php
+++ b/Tests/SymfonyIntegration/AppKernel.php
@@ -1,0 +1,55 @@
+<?php
+
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\Config\Loader\LoaderInterface;
+
+/**
+ * Appkernel for tests
+ */
+class AppKernel extends Kernel
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function registerBundles()
+    {
+        date_default_timezone_set('UTC');
+
+        $bundles = array(
+            new Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
+            new Symfony\Bundle\TwigBundle\TwigBundle(),
+            new PrestaShop\TranslationToolsBundle\TranslationToolsBundle(),
+        );
+
+        return $bundles;
+    }
+
+    /**
+     * @return null
+     */
+    public function registerContainerConfiguration(LoaderInterface $loader)
+    {
+        $loader->load(__DIR__ . '/config_test.yml');
+    }
+
+    /**
+     * @return string
+     */
+    public function getCacheDir()
+    {
+        return $this->guessTempDirectoryFor('cache');
+    }
+
+    /**
+     * @return string
+     */
+    public function getLogDir()
+    {
+        return $this->guessTempDirectoryFor('logs');
+    }
+
+    private function guessTempDirectoryFor($dirname)
+    {
+        return is_writable(__DIR__ . '/../../../../build/tmp') ? __DIR__ . '/build/tmp/' . $dirname : sys_get_temp_dir() . '/TranslationToolsBundleTest/' . $dirname;
+    }
+}

--- a/Tests/SymfonyIntegration/config_test.yml
+++ b/Tests/SymfonyIntegration/config_test.yml
@@ -1,0 +1,17 @@
+framework:
+    secret: test
+    test: ~
+    session:
+        storage_id: session.storage.mock_file
+    form:            true
+    csrf_protection: true
+    validation:
+        enabled: true
+        enable_annotations: true
+
+
+# Twig Configuration
+twig:
+    autoescape:       "name"
+    debug:            "%kernel.debug%"
+    strict_variables: "%kernel.debug%"

--- a/Tests/SymfonyIntegration/run.php
+++ b/Tests/SymfonyIntegration/run.php
@@ -1,0 +1,13 @@
+<?php
+
+require_once __DIR__ . '/../bootstrap.php';
+require_once __DIR__.'/AppKernel.php';
+
+use PHPUnit\Framework\Assert as Assert;
+use PrestaShop\TranslationToolsBundle\Translation\Compiler\Smarty\TranslationTemplateCompiler;
+
+$kernel = new AppKernel('test', false);
+$kernel->boot();
+
+$smartyTemplateCompiler = $kernel->getContainer()->get('prestashop.compiler.smarty.template');
+Assert::assertInstanceOf(TranslationTemplateCompiler::class, $smartyTemplateCompiler);

--- a/Tests/SymfonyIntegration/run.php
+++ b/Tests/SymfonyIntegration/run.php
@@ -1,7 +1,7 @@
 <?php
 
 require_once __DIR__ . '/../bootstrap.php';
-require_once __DIR__.'/AppKernel.php';
+require_once __DIR__ . '/AppKernel.php';
 
 use PHPUnit\Framework\Assert as Assert;
 use PrestaShop\TranslationToolsBundle\Translation\Compiler\Smarty\TranslationTemplateCompiler;

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,8 @@
     "doctrine/common": "^2.10.0",
     "phpunit/phpunit": "^7.5 || ^8.5",
     "symfony/framework-bundle": "^3.4 || ^4.4 || ^5.0",
-    "symfony/translation": "^3.4 || ^4.4 || ^5.0"
+    "symfony/symfony": "^4",
+    "symfony/translation": "^3.4 || ^4.4 || ^5.0",
+    "symfony/twig-bundle": "^4"
   }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add a Symfony integration test. See after the table for more informations
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| How to test?      | CI is green
| Possible impacts? | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

This repository contains a Bundle, that provides needed configuration items to be integrated into a Symfony application: there is two Compiler Passes, a standard Configuration file, a standard Extension file, a YAML services definition file...

If today we merge changes that modify the above files and make them invalid, the CI will not detect this.

This test aims to fix this.

This test builds a very small Symfony application, as small as possible, with as few configuration as possible, and simply add the TranslationToolsBundle to it then boot it. If we merge changes that modify the above files and make them invalid, this test will fail. It's very simple. This tests simply verifies "this Bundle can be added to a Symfony application, this will not crash".