### PR TITLE
Add ability to exclude directories when extracting

### DIFF
--- a/Tests/Translation/Extractor/PhpExtractorTest.php
+++ b/Tests/Translation/Extractor/PhpExtractorTest.php
@@ -25,21 +25,21 @@ class PhpExtractorTest extends TestCase
     {
         $messageCatalogue = $this->buildMessageCatalogue('fixtures/TestController.php');
 
-        $this->assertTrue($messageCatalogue->defines('Fingers', 'admin.product.help'));
+        $this->assertTrue($messageCatalogue->defines('Fingers', 'Admin.Product.Help'));
     }
 
     public function testItExtractsTransMethodWithPrestashopStyleParameters()
     {
         $messageCatalogue = $this->buildMessageCatalogue('fixtures/TestController.php');
 
-        $this->assertTrue($messageCatalogue->defines('This is how PrestaShop does it', 'admin.product.help'));
+        $this->assertTrue($messageCatalogue->defines('This is how PrestaShop does it', 'Admin.Product.Help'));
     }
 
     public function testItWorksWithMultiLineTrans()
     {
         $messageCatalogue = $this->buildMessageCatalogue('fixtures/TestController.php');
 
-        $this->assertTrue($messageCatalogue->defines('This is how symfony does it', 'admin.product.help'));
+        $this->assertTrue($messageCatalogue->defines('This is how symfony does it', 'Admin.Product.Help'));
     }
 
     public function testItExtractsTransWithoutDomain()
@@ -180,6 +180,72 @@ class PhpExtractorTest extends TestCase
                 ],
             ],
         ];
+    }
+
+    public function testExtractFromDirectoryWithoutExclusion(): void
+    {
+        $messageCatalogue = $this->buildMessageCatalogue('directory/');
+
+        $catalogue = $messageCatalogue->all();
+        $this->assertCount(2, array_keys($catalogue));
+        $this->assertCount(3, $catalogue['messages']);
+        $this->assertCount(2, $catalogue['Admin.Product.Help']);
+
+        $this->verifyCatalogue($messageCatalogue, [
+            'messages' => [
+                'SecondSubdirShop' => 'SecondSubdirShop',
+                'SubdirShop' => 'SubdirShop',
+                'Shop' => 'Shop',
+            ],
+            'Admin.Product.Help' => [
+                'SubdirFingers' => 'SubdirFingers',
+                'Fingers' => 'Fingers',
+            ],
+        ]);
+    }
+
+    public function testExtractFromDirectoryExcludingSubDirectories(): void
+    {
+        // Exclude one directory
+        $messageCatalogue = new MessageCatalogue('en');
+        $this->phpExtractor
+            ->setExcludedDirectories(['subdirectory'])
+            ->extract($this->getResource('directory/'), $messageCatalogue);
+
+        $catalogue = $messageCatalogue->all();
+        $this->assertCount(2, array_keys($catalogue));
+        $this->assertCount(2, $catalogue['messages']);
+        $this->assertCount(1, $catalogue['Admin.Product.Help']);
+
+        $this->verifyCatalogue($messageCatalogue, [
+            'messages' => [
+                'SecondSubdirShop' => 'SecondSubdirShop',
+                'Shop' => 'Shop',
+            ],
+            'Admin.Product.Help' => [
+                'Fingers' => 'Fingers',
+            ],
+        ]);
+
+        // Exclude multiple directories
+        $messageCatalogue = new MessageCatalogue('en');
+        $this->phpExtractor
+            ->setExcludedDirectories(['subdirectory', 'subdirectory2'])
+            ->extract($this->getResource('directory/'), $messageCatalogue);
+
+        $catalogue = $messageCatalogue->all();
+        $this->assertCount(2, array_keys($catalogue));
+        $this->assertCount(1, $catalogue['messages']);
+        $this->assertCount(1, $catalogue['Admin.Product.Help']);
+
+        $this->verifyCatalogue($messageCatalogue, [
+            'messages' => [
+                'Shop' => 'Shop',
+            ],
+            'Admin.Product.Help' => [
+                'Fingers' => 'Fingers',
+            ],
+        ]);
     }
 
     /**

--- a/Tests/Translation/Extractor/SmartyExtractorTest.php
+++ b/Tests/Translation/Extractor/SmartyExtractorTest.php
@@ -132,6 +132,68 @@ class SmartyExtractorTest extends TestCase
         return new SmartyExtractor($compiler, $includeExternalModules);
     }
 
+    public function testExtractFromDirectoryWithoutExclusion(): void
+    {
+        $messageCatalogue = new MessageCatalogue('en');
+        $this->buildExtractor(SmartyExtractor::INCLUDE_EXTERNAL_MODULES)->extract(
+            parent::getResource('directory/'), $messageCatalogue
+        );
+
+        $catalogue = $messageCatalogue->all();
+        $this->assertCount(1, array_keys($catalogue));
+        $this->assertCount(5, $catalogue['Modules.Wirepayment.Shop']);
+
+        $this->verifyCatalogue($messageCatalogue, [
+            'Modules.Wirepayment.Shop' => [
+                'Your order on %s is complete.' => 'Your order on %s is complete.',
+                'Please send us a bank wire with:' => 'Please send us a bank wire with:',
+                'If you have questions, comments or concerns, please contact our [1]expert customer support team[/1].' => 'If you have questions, comments or concerns, please contact our [1]expert customer support team[/1].',
+                'Please specify your order reference %s in the bankwire description.' => 'Please specify your order reference %s in the bankwire description.',
+                'Your order will be sent as soon as we receive payment.' => 'Your order will be sent as soon as we receive payment.',
+            ],
+        ]);
+    }
+
+    public function testExtractFromDirectoryExcludingDirectories(): void
+    {
+        // Exclude one directory
+        $messageCatalogue = new MessageCatalogue('en');
+        $this->buildExtractor(SmartyExtractor::INCLUDE_EXTERNAL_MODULES)
+            ->setExcludedDirectories(['subdirectory'])
+            ->extract(parent::getResource('directory/'), $messageCatalogue);
+
+        $catalogue = $messageCatalogue->all();
+        $this->assertCount(1, array_keys($catalogue));
+        $this->assertCount(4, $catalogue['Modules.Wirepayment.Shop']);
+
+        $this->verifyCatalogue($messageCatalogue, [
+            'Modules.Wirepayment.Shop' => [
+                'Your order on %s is complete.' => 'Your order on %s is complete.',
+                'Please send us a bank wire with:' => 'Please send us a bank wire with:',
+                'If you have questions, comments or concerns, please contact our [1]expert customer support team[/1].' => 'If you have questions, comments or concerns, please contact our [1]expert customer support team[/1].',
+                'Your order will be sent as soon as we receive payment.' => 'Your order will be sent as soon as we receive payment.',
+            ],
+        ]);
+
+        // Exclude multiple directories
+        $messageCatalogue = new MessageCatalogue('en');
+        $this->buildExtractor(SmartyExtractor::INCLUDE_EXTERNAL_MODULES)
+            ->setExcludedDirectories(['subdirectory', 'subdirectory2'])
+            ->extract(parent::getResource('directory/'), $messageCatalogue);
+
+        $catalogue = $messageCatalogue->all();
+        $this->assertCount(1, array_keys($catalogue));
+        $this->assertCount(3, $catalogue['Modules.Wirepayment.Shop']);
+
+        $this->verifyCatalogue($messageCatalogue, [
+            'Modules.Wirepayment.Shop' => [
+                'Your order on %s is complete.' => 'Your order on %s is complete.',
+                'Please send us a bank wire with:' => 'Please send us a bank wire with:',
+                'If you have questions, comments or concerns, please contact our [1]expert customer support team[/1].' => 'If you have questions, comments or concerns, please contact our [1]expert customer support team[/1].',
+            ],
+        ]);
+    }
+
     /**
      * @param string $resourceName
      *

--- a/Tests/resources/directory/TestController.php
+++ b/Tests/resources/directory/TestController.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Test;
+
 class TestController
 {
     public function init()
@@ -9,6 +11,6 @@ class TestController
 
     public function productAction()
     {
-        $this->trans('Shop', [], 'Admin.Product.Help');
+        $this->trans('Fingers', [], 'Admin.Product.Help');
     }
 }

--- a/Tests/resources/directory/root_template.tpl
+++ b/Tests/resources/directory/root_template.tpl
@@ -1,0 +1,14 @@
+{*
+* This file is authored by PrestaShop SA and Contributors <contact@prestashop.com>
+*
+* It is distributed under MIT license.
+*
+* For the full copyright and license information, please view the LICENSE
+* file that was distributed with this source code.
+*}
+<p>
+  {l s='Your order on %s is complete.' sprintf=[$shop_name] d='Modules.Wirepayment.Shop'}<br/>
+  {l s='Please send us a bank wire with:' d='Modules.Wirepayment.Shop'}
+  {l s='If you have questions, comments or concerns, please contact our [1]expert customer support team[/1].' d='Modules.Wirepayment.Shop' sprintf=['[1]' => "<a href='{$contact_url}'>", '[/1]' => '</a>']}
+</p>
+{include file='module:ps_wirepayment/views/templates/hook/_partials/payment_infos.tpl'}

--- a/Tests/resources/directory/subdirectory/SubDirTestController.php
+++ b/Tests/resources/directory/subdirectory/SubDirTestController.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Test\Subdirectory;
+
+class SubDirTestController
+{
+    public function init()
+    {
+        $this->l('SubdirShop');
+    }
+
+    public function productAction()
+    {
+        $this->trans('SubdirFingers', [], 'Admin.Product.Help');
+    }
+}

--- a/Tests/resources/directory/subdirectory/first_sub_template.tpl
+++ b/Tests/resources/directory/subdirectory/first_sub_template.tpl
@@ -1,0 +1,12 @@
+{*
+* This file is authored by PrestaShop SA and Contributors <contact@prestashop.com>
+*
+* It is distributed under MIT license.
+*
+* For the full copyright and license information, please view the LICENSE
+* file that was distributed with this source code.
+*}
+<p>
+  {l s='Please specify your order reference %s in the bankwire description.' sprintf=[$shop_name] d='Modules.Wirepayment.Shop'}<br/>
+</p>
+{include file='module:ps_wirepayment/views/templates/hook/_partials/payment_infos.tpl'}

--- a/Tests/resources/directory/subdirectory2/SecondSubDirTestController.php
+++ b/Tests/resources/directory/subdirectory2/SecondSubDirTestController.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Test\SecondSubdirectory;
+
+class SecondSubDirTestController
+{
+    public function init()
+    {
+        $this->l('SecondSubdirShop');
+    }
+}

--- a/Tests/resources/directory/subdirectory2/second_sub_template.tpl
+++ b/Tests/resources/directory/subdirectory2/second_sub_template.tpl
@@ -1,0 +1,12 @@
+{*
+* This file is authored by PrestaShop SA and Contributors <contact@prestashop.com>
+*
+* It is distributed under MIT license.
+*
+* For the full copyright and license information, please view the LICENSE
+* file that was distributed with this source code.
+*}
+<p>
+  {l s='Your order will be sent as soon as we receive payment.' sprintf=[$shop_name] d='Modules.Wirepayment.Shop'}<br/>
+</p>
+{include file='module:ps_wirepayment/views/templates/hook/_partials/payment_infos.tpl'}

--- a/Tests/resources/directory/twig/subdirectory/index.html.twig
+++ b/Tests/resources/directory/twig/subdirectory/index.html.twig
@@ -1,0 +1,4 @@
+<p>Any not translated text</p>
+And not in a HTML tag
+
+{{ 'Translate me please'|trans({}, 'Test.Translation.Firstsubdir') }}

--- a/Tests/resources/directory/twig/subdirectory2/index.html.twig
+++ b/Tests/resources/directory/twig/subdirectory2/index.html.twig
@@ -1,0 +1,2 @@
+Some text
+{{ 'string to translate'|trans({}, 'Test.Translation.Secondsubdir') }}

--- a/Tests/resources/dump/en/messages.xlf
+++ b/Tests/resources/dump/en/messages.xlf
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+  <file original="classes/helper/Helper.php" source-language="en" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="dd5c8bf51558ffcbe5007071908e9524">
+        <source>third</source>
+        <target>third</target>
+        <note>Line: 6</note>
+      </trans-unit>
+    </body>
+  </file>
   <file original="controllers/admin/AdminAccessController.php" source-language="en" target-language="en" datatype="plaintext">
     <body>
       <trans-unit id="8b04d5e3775d298e78455efc5ca404d5">
@@ -9,20 +18,29 @@
       </trans-unit>
     </body>
   </file>
+  <file original="none (skip)" source-language="en" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="5098d245aa911c02a50e276087c0b4a9">
+        <source>seventh</source>
+        <target>seventh</target>
+        <note>Line: 0</note>
+      </trans-unit>
+    </body>
+  </file>
+  <file original="override/classes/pdf/PDF.php" source-language="en" target-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="93c38fcf0d200be001335ef572650346">
+        <source>sixth</source>
+        <target>sixth</target>
+        <note>Line: 0</note>
+      </trans-unit>
+    </body>
+  </file>
   <file original="override/controllers/admin/AdminAccessController.php" source-language="en" target-language="en" datatype="plaintext">
     <body>
       <trans-unit id="a9f0e61a137d86aa9db53465e0801612">
         <source>second</source>
         <target>second</target>
-        <note>Line: 6</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="classes/helper/Helper.php" source-language="en" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="dd5c8bf51558ffcbe5007071908e9524">
-        <source>third</source>
-        <target>third</target>
         <note>Line: 6</note>
       </trans-unit>
     </body>
@@ -41,24 +59,6 @@
       <trans-unit id="0883a6520e6eb6c9304dcfb71034d053">
         <source>fifth</source>
         <target>fifth</target>
-        <note>Line: 0</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="override/classes/pdf/PDF.php" source-language="en" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="93c38fcf0d200be001335ef572650346">
-        <source>sixth</source>
-        <target>sixth</target>
-        <note>Line: 0</note>
-      </trans-unit>
-    </body>
-  </file>
-  <file original="none (skip)" source-language="en" target-language="en" datatype="plaintext">
-    <body>
-      <trans-unit id="5098d245aa911c02a50e276087c0b4a9">
-        <source>seventh</source>
-        <target>seventh</target>
         <note>Line: 0</note>
       </trans-unit>
     </body>

--- a/Tests/resources/fixtures/TestController.php
+++ b/Tests/resources/fixtures/TestController.php
@@ -11,7 +11,7 @@ class TestController
 
     public function productAction()
     {
-        $this->trans('Fingers', [], 'admin.product.help');
+        $this->trans('Fingers', [], 'Admin.Product.Help');
     }
 
     public function nothingAction()
@@ -25,18 +25,18 @@ class TestController
         $this->trans(
             'This is how symfony does it',
             [],
-            'admin.product.help'
+            'Admin.Product.Help'
         );
 
         $this->trans(
             'This is how PrestaShop does it',
-            'admin.product.help',
+            'Admin.Product.Help',
             []
         );
 
         $this->trans(
             'Look, no parameters',
-            'admin.product.help'
+            'Admin.Product.Help'
         );
 
         $this->trans(

--- a/Tests/resources/fixtures/twig/payment_return.html.twig
+++ b/Tests/resources/fixtures/twig/payment_return.html.twig
@@ -1,0 +1,29 @@
+{#*
+* This file is authored by PrestaShop SA and Contributors <contact@prestashop.com>
+*
+* It is distributed under MIT license.
+*
+* For the full copyright and license information, please view the LICENSE
+* file that was distributed with this source code.
+*#}
+
+{% if status == 'ok' %}
+    <p>
+      {{ 'Your order on %s is complete.'|trans({'%s': shop_name}, 'Modules.Wirepayment.Shop') }}<br/>{# here is a comment #}
+      {{ 'Please send us a bank wire with:'|trans({}, 'Modules.Wirepayment.Shop') }}<br/>
+    </p>
+    {% include '@Modules/ps_wirepayment/views/templates/hook/_partials/payment_infos.html.twig' %}
+
+    <p>
+      {{ 'Please specify your order reference %s in the bankwire description.'|trans({'%s': reference}, 'Modules.Wirepayment.Shop') }}<br/>
+      {{ 'We\'ve also sent you this information by e-mail.'|trans({}, 'Modules.Wirepayment.Shop') }}
+    </p>
+    <strong>{{ 'Your order will be sent as soon as we receive payment.'|trans({}, 'Modules.Wirepayment.Shop') }}</strong>
+    <p>
+      {{ 'If you have questions, comments or concerns, please contact our [1]expert customer support team[/1].'|trans({}, 'Modules.Wirepayment.Shop')|replace({'[1]': '<a href=' ~ contact_url ~ '>', '[/1]': '</a>'})|raw }}
+    </p>
+{% else %}
+    <p class="warning">
+      {{ 'We noticed a problem with your order. If you think this is an error, feel free to contact our [1]expert customer support team[/1].'|trans({}, 'Modules.Wirepayment.Shop')|replace({'[1]': '<a href=' ~ contact_url ~ '>', '[/1]': '</a>'})|raw }}
+    </p>
+{% endif %}

--- a/Translation/Extractor/CrowdinPhpExtractor.php
+++ b/Translation/Extractor/CrowdinPhpExtractor.php
@@ -36,6 +36,8 @@ use Symfony\Component\Translation\MessageCatalogue;
 
 class CrowdinPhpExtractor extends AbstractFileExtractor implements ExtractorInterface
 {
+    use TraitExtractor;
+
     /**
      * Prefix for new found message.
      *
@@ -113,6 +115,9 @@ class CrowdinPhpExtractor extends AbstractFileExtractor implements ExtractorInte
     {
         $finder = new Finder();
 
-        return $finder->files()->name('*.php')->in($directory);
+        return $finder->files()
+            ->name('*.php')
+            ->in($directory)
+            ->exclude($this->getExcludedDirectories());
     }
 }

--- a/Translation/Extractor/PhpExtractor.php
+++ b/Translation/Extractor/PhpExtractor.php
@@ -178,6 +178,10 @@ class PhpExtractor extends AbstractFileExtractor implements ExtractorInterface
      */
     protected function extractFromDirectory($directory)
     {
-        return $this->getFinder()->files()->name('*.php')->in($directory);
+        return $this->getFinder()
+            ->files()
+            ->name('*.php')
+            ->exclude($this->getExcludedDirectories())
+            ->in($directory);
     }
 }

--- a/Translation/Extractor/SmartyExtractor.php
+++ b/Translation/Extractor/SmartyExtractor.php
@@ -137,6 +137,9 @@ class SmartyExtractor extends AbstractFileExtractor implements ExtractorInterfac
      */
     protected function extractFromDirectory($directory)
     {
-        return $this->getFinder()->name('*.tpl')->in($directory);
+        return $this->getFinder()
+            ->name('*.tpl')
+            ->in($directory)
+            ->exclude($this->getExcludedDirectories());
     }
 }

--- a/Translation/Extractor/TraitExtractor.php
+++ b/Translation/Extractor/TraitExtractor.php
@@ -39,6 +39,25 @@ trait TraitExtractor
     protected $finder;
 
     /**
+     * Directories ignored when scanning files for catalogue extraction.
+     *
+     * @var array
+     */
+    protected $excludedDirectories = [];
+
+    public function getExcludedDirectories(): array
+    {
+        return $this->excludedDirectories;
+    }
+
+    public function setExcludedDirectories(array $excludedDirectories): self
+    {
+        $this->excludedDirectories = $excludedDirectories;
+
+        return $this;
+    }
+
+    /**
      * @param $domainName
      *
      * @return string
@@ -57,7 +76,7 @@ trait TraitExtractor
      * @param $file
      * @param $line
      *
-     * @return array
+     * @return array|null
      */
     public function getEntryComment(array $comments, $file, $line)
     {
@@ -66,6 +85,8 @@ trait TraitExtractor
                 return $comment['comment'];
             }
         }
+
+        return null;
     }
 
     /**

--- a/Translation/Extractor/TwigExtractor.php
+++ b/Translation/Extractor/TwigExtractor.php
@@ -30,6 +30,7 @@ namespace PrestaShop\TranslationToolsBundle\Translation\Extractor;
 use PrestaShop\TranslationToolsBundle\Twig\Lexer;
 use Symfony\Bridge\Twig\Extension\TranslationExtension;
 use Symfony\Bridge\Twig\Translation\TwigExtractor as BaseTwigExtractor;
+use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
 use Symfony\Component\Translation\Extractor\ExtractorInterface;
 use Symfony\Component\Translation\MessageCatalogue;
@@ -154,28 +155,15 @@ class TwigExtractor extends BaseTwigExtractor implements ExtractorInterface
     }
 
     /**
-     * @param $comments
-     * @param $file
-     * @param $line
-     *
-     * @return array
-     */
-    public function getEntryComment($comments, $file, $line)
-    {
-        foreach ($comments as $comment) {
-            if ($comment['file'] == $file && $comment['line'] == $line) {
-                return $comment['comment'];
-            }
-        }
-    }
-
-    /**
      * @param string $directory
      *
      * @return Finder
      */
     protected function extractFromDirectory($directory)
     {
-        return $this->getFinder()->files()->name('*.twig')->in($directory);
+        return $this->getFinder()->files()
+            ->name('*.twig')
+            ->in($directory)
+            ->exclude($this->getExcludedDirectories());
     }
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Allow to set directories that will be excluded when scanning folders for catalogue extraction.
| Type?             | improvement
| BC breaks?        | yes
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/issues/24987
| How to test?      | See https://github.com/PrestaShop/PrestaShop/issues/24987
| Possible impacts? | -

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
