### PR TITLE
Remove TreeBuilder deprecation

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -20,8 +20,12 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $treeBuilder->root('translation_tools');
+        if (method_exists(TreeBuilder::class, 'getRootNode')) {
+            $treeBuilder = new TreeBuilder('translation_tools');
+        } else {
+            $treeBuilder = new TreeBuilder();
+            $treeBuilder->root('translation_tools');
+        }
 
         return $treeBuilder;
     }

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * This file is authored by PrestaShop SA and Contributors <contact@prestashop.com>
+ *
+ * It is distributed under MIT license.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace PrestaShop\TranslationToolsBundle\Tests\DependencyInjection;
+
+use PrestaShop\TranslationToolsBundle\DependencyInjection\Configuration;
+use PrestaShop\TranslationToolsBundle\Tests\PhpUnit\TestCase;
+
+class ConfigurationTest extends TestCase
+{
+    public function testNewConfiguration()
+    {
+        $configuration = new Configuration();
+        $this->assertSame('translation_tools', $configuration->getConfigTreeBuilder()->buildTree()->getName());
+    }
+}

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -8,6 +8,8 @@
  * file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 namespace PrestaShop\TranslationToolsBundle\Tests\DependencyInjection;
 
 use PrestaShop\TranslationToolsBundle\DependencyInjection\Configuration;
@@ -15,7 +17,7 @@ use PrestaShop\TranslationToolsBundle\Tests\PhpUnit\TestCase;
 
 class ConfigurationTest extends TestCase
 {
-    public function testNewConfiguration()
+    public function testNewConfiguration(): void
     {
         $configuration = new Configuration();
         $this->assertSame('translation_tools', $configuration->getConfigTreeBuilder()->buildTree()->getName());


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Since Symfony 4, `TreeBuilder`'s constructor should be called with the root node name as first argument instead of calling the `root()` method later on. To keep backward compatibility, this PR checks that the `TreeBuilder` class has a method called `getRootNode` which appeared when the `root()` method was deprecated, to know how to call `TreeBuilder`'s constructor. This is inspired from https://github.com/PrestaShop/TranslationToolsBundle/pull/95#issuecomment-908505246 but without using reflection.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     |
| How to test?      | CI should be green
| Possible impacts? | 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
