### PR TITLE
TranslationNodeVisitor loses messages when parsing multiple files

### DIFF
--- a/Tests/PhpUnit/TestCase.php
+++ b/Tests/PhpUnit/TestCase.php
@@ -84,5 +84,24 @@ class TestCase extends PhpUnitTestCase
                 );
             }
         }
+
+        // Now check that everything found was defined in expected
+        foreach ($domains as $catalogDomain) {
+            $this->assertContains(
+                $catalogDomain,
+                array_keys($expected),
+                sprintf('Found domain "%s" is not defined in expected domains %s', $catalogDomain, print_r(array_keys($expected), true))
+            );
+
+            $domainMessages = $messageCatalogue->all($catalogDomain);
+            $expectedDomainMessages = $expected[$catalogDomain];
+            foreach ($domainMessages as $domainMessage) {
+                $this->assertContains(
+                    $domainMessage,
+                    $expectedDomainMessages,
+                    sprintf('Found message "%s" is not defined in expected domain %s', $domainMessage, $catalogDomain)
+                );
+            }
+        }
     }
 }

--- a/Tests/Translation/Extractor/SmartyExtractorTest.php
+++ b/Tests/Translation/Extractor/SmartyExtractorTest.php
@@ -69,6 +69,8 @@ class SmartyExtractorTest extends TestCase
                 'Please check that you have the rights to write to the folders /app/cache/ and /themes/',
                 'Download theme',
                 'Downloading',
+                'How to use parents/child themes',
+                'Upload child theme',
                 'Information',
                 'By using this method you can only override the CSS of your theme.',
                 'By using this method you can override the CSS and html of your theme, and add analytics tags.',

--- a/Tests/Translation/Extractor/TwigExtractorTest.php
+++ b/Tests/Translation/Extractor/TwigExtractorTest.php
@@ -26,7 +26,10 @@ class TwigExtractorTest extends TestCase
      */
     public function testExtractWithDomain(): void
     {
-        $messageCatalogue = $this->buildMessageCatalogue('payment_return.html.twig');
+        $messageCatalogue = $this->buildMessageCatalogue([
+            'payment_return.html.twig',
+            'log_alert.html.twig',
+        ]);
 
         $expected = [
             'Modules.Wirepayment.Shop' => [
@@ -37,6 +40,12 @@ class TwigExtractorTest extends TestCase
                 'Your order will be sent as soon as we receive payment.',
                 'If you have questions, comments or concerns, please contact our [1]expert customer support team[/1].',
                 'We noticed a problem with your order. If you think this is an error, feel free to contact our [1]expert customer support team[/1].',
+            ],
+            'Emails.Body' => [
+                'Hi {firstname} {lastname},',
+                'You have received a new log alert',
+                '[1]Warning:[/1] you have received a new log alert in your Back Office.',
+                'You can check for it in the [1]Advanced Parameters > Logs[/1] section of your back office.',
             ],
         ];
 
@@ -81,6 +90,28 @@ class TwigExtractorTest extends TestCase
                     'comment' => null,
                 ],
             ],
+            'Emails.Body' => [
+                'Hi {firstname} {lastname},' => [
+                    'file' => $fixtureDirectory . '/log_alert.html.twig',
+                    'line' => 7,
+                    'comment' => null,
+                ],
+                'You have received a new log alert' => [
+                    'file' => $fixtureDirectory . '/log_alert.html.twig',
+                    'line' => 24,
+                    'comment' => null,
+                ],
+                '[1]Warning:[/1] you have received a new log alert in your Back Office.' => [
+                    'file' => $fixtureDirectory . '/log_alert.html.twig',
+                    'line' => 29,
+                    'comment' => null,
+                ],
+                'You can check for it in the [1]Advanced Parameters > Logs[/1] section of your back office.' => [
+                    'file' => $fixtureDirectory . '/log_alert.html.twig',
+                    'line' => 30,
+                    'comment' => null,
+                ],
+            ],
         ];
 
         $this->verifyCatalogueMetadata($messageCatalogue, $expectedMetadata);
@@ -89,10 +120,13 @@ class TwigExtractorTest extends TestCase
     /**
      * @throws Error
      */
-    private function buildMessageCatalogue(string $fixtureResource): MessageCatalogue
+    private function buildMessageCatalogue(array $fixtureResources): MessageCatalogue
     {
         $messageCatalogue = new MessageCatalogue('en');
-        $this->buildExtractor()->extract($this->getResource($fixtureResource), $messageCatalogue);
+        $extractor = $this->buildExtractor();
+        foreach ($fixtureResources as $fixtureResource) {
+            $extractor->extract($this->getResource($fixtureResource), $messageCatalogue);
+        }
 
         return $messageCatalogue;
     }

--- a/Tests/resources/fixtures/twig/log_alert.html.twig
+++ b/Tests/resources/fixtures/twig/log_alert.html.twig
@@ -1,0 +1,39 @@
+{% extends '@MailThemes/classic/components/layout.html.twig' %}
+
+{% block content %}
+<tr>
+  <td align="center" class="titleblock">
+    <font size="2" face="{{ languageDefaultFont }}Open-sans, sans-serif" color="#555454">
+      <span class="title">{{ 'Hi {firstname} {lastname},'|trans({}, 'Emails.Body', locale) }}</span>
+    </font>
+  </td>
+</tr>
+<tr>
+  <td class="space_footer">&nbsp;</td>
+</tr>
+<tr>
+  <td class="box" style="border:1px solid #D6D4D4;">
+    <table class="table">
+      <tr>
+        <td width="10">&nbsp;</td>
+        <td>
+          <font size="2" face="{{ languageDefaultFont }}Open-sans, sans-serif" color="#555454">
+            {% if templateType == 'html' %}
+
+              <p style="border-bottom:1px solid #D6D4D4;">
+                {{ 'You have received a new log alert'|trans({}, 'Emails.Body', locale)|raw }}
+              </p>
+            
+{% endif %}
+            <span>
+              {{ '[1]Warning:[/1] you have received a new log alert in your Back Office.'|trans({'[1]': '<span><strong>', '[/1]': '</strong></span>'}, 'Emails.Body', locale)|raw }}<br/><br/>
+              {{ 'You can check for it in the [1]Advanced Parameters > Logs[/1] section of your back office.'|trans({'[1]': '<span><strong>', '[/1]': '</strong></span>'}, 'Emails.Body', locale)|raw }}
+            </span>
+          </font>
+        </td>
+        <td width="10">&nbsp;</td>
+      </tr>
+    </table>
+  </td>
+</tr>
+{% endblock %}

--- a/Twig/NodeVisitor/TranslationNodeVisitor.php
+++ b/Twig/NodeVisitor/TranslationNodeVisitor.php
@@ -31,11 +31,13 @@ class TranslationNodeVisitor extends AbstractNodeVisitor
 
     public function enable()
     {
+        $this->messages = [];
         $this->baseTranslationNodeVisitor->enable();
     }
 
     public function disable()
     {
+        $this->messages = [];
         $this->baseTranslationNodeVisitor->disable();
     }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | This PR aims to fix a bug introduced in this commit https://github.com/PrestaShop/TranslationToolsBundle/commit/deaf4ce125696b94debbf56ef23bb94ccd0bd866 The TranslationNodeVisitor did not clear its messages on each parsing, so only first messages were correctly extracted. Resetting messages when the visitor is enabled/disabled does the trick, and the tests were updated to detect such mistakes now.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | ~
| How to test?      | ~
| Possible impacts? | ~

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
