### PR TITLE
Prevent TypeError when first-class callable syntax is encountered

### DIFF
--- a/Tests/resources/fixtures/TestController.php
+++ b/Tests/resources/fixtures/TestController.php
@@ -18,6 +18,13 @@ class TestController
     {
         // the parser should not capture this
         $version = phpversion();
+
+        // encountering first-class callable syntax should not cause the extractor to fail with an error
+        $closure = $this->fooAction(...);
+
+        $messages = array_map($this->trans(...), [
+            'Extracting messages translated this way is not supported',
+        ]);
     }
 
     public function fooAction()

--- a/Translation/Extractor/Visitor/Translation/ExplicitTranslationCall.php
+++ b/Translation/Extractor/Visitor/Translation/ExplicitTranslationCall.php
@@ -33,8 +33,11 @@ class ExplicitTranslationCall extends AbstractTranslationNodeVisitor
         /** @var $node \PhpParser\Node\Expr\MethodCall|\PhpParser\Node\Expr\FuncCall */
         $nodeName = $this->getNodeName($node);
 
-        $key = $this->getValue($node->args[0]);
-        if (!in_array($nodeName, self::SUPPORTED_METHODS) || empty($key)) {
+        if (
+            !in_array($nodeName, self::SUPPORTED_METHODS)
+            || !$node->args[0] instanceof Node\Arg
+            || null === $key = $this->getValue($node->args[0])
+        ) {
             return [];
         }
 
@@ -79,9 +82,9 @@ class ExplicitTranslationCall extends AbstractTranslationNodeVisitor
     {
         if ($arg->value instanceof Node\Scalar\String_) {
             return $arg->value->value;
-        } elseif (gettype($arg) === 'string') {
-            return $arg->value;
         }
+
+        return null;
     }
 
     /**


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Extracting translations from a PHP file containing the [first-class callable syntax](https://www.php.net/manual/en/functions.first_class_callable_syntax.php) results in a `TypeError` being thrown in `ExplicitTranslationCall::extractFrom()`, because instances of [`PhpParser\Node\VariadicPlaceholder`](https://github.com/nikic/PHP-Parser/blob/master/lib/PhpParser/Node/VariadicPlaceholder.php) representing the "..." of the new (?) syntax are passed to the `ExplicitTranslationCall::getValue()` method that only allows `PhpParser\Node\Arg` as an argument. This PR aims to prevent this kind of errors by checking the type of the AST node before passing it to the `getValue()` method.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | N/A
| Sponsor company   | N/A
| How to test?      | Usages of first-class callable syntax have been added to fixture files used in unit tests. Running the tests without changes in the node visitor results in errors.

Since the syntax was introduced in PHP 8.1, which is officially supported by PrestaShop 8.x, I believe a patch should also be applied to version 5.x of the bundle (used by these PS versions).